### PR TITLE
Add string type to SimpleXML::__get

### DIFF
--- a/SimpleXML/SimpleXML.php
+++ b/SimpleXML/SimpleXML.php
@@ -23,7 +23,7 @@ class SimpleXMLElement implements Traversable {
 
 	/**
      * Provides access to element's children
-     * @param $name child name
+     * @param string $name child name
      * @return SimpleXMLElement[]
      */
     function __get($name) {}


### PR DESCRIPTION
There must be string before `$name`, because phpdoc assumes `$name instanceof child::class`